### PR TITLE
users can now override the contentWidth of the toolbar

### DIFF
--- a/RichEditorView/Assets/editor/rich_editor.js
+++ b/RichEditorView/Assets/editor/rich_editor.js
@@ -76,7 +76,7 @@ RE.removeFormat = function() {
 }
 
 RE.setFontSize = function(size) {
-    RE.editor.style.fontSize = size;
+    document.execCommand("fontSize", false, size);
 }
 
 RE.setBackgroundColor = function(color) {

--- a/RichEditorView/Classes/RichEditorToolbar.swift
+++ b/RichEditorView/Classes/RichEditorToolbar.swift
@@ -83,9 +83,24 @@ public class RichEditorToolbar: UIView {
             updateToolbar()
         }
     }
-
+    
+    /**
+        The inner toolbar that contains the list of options as UIBarButtonItems.
+    */
+    public var toolbar: UIToolbar
+    
+    /**
+        Set this to specify a content width.  Not setting this will have the editor try to 
+        calculate the width based on the options chosen.
+    */
+    public var contentWidth : CGFloat? {
+        didSet {
+            updateToolbar()
+        }
+    }
+    
     private var toolbarScroll: UIScrollView
-    private var toolbar: UIToolbar
+    
     private var backgroundToolbar: UIToolbar
     
     public override init(frame: CGRect) {
@@ -141,6 +156,13 @@ public class RichEditorToolbar: UIView {
         }
         toolbar.items = buttons
 
+        if contentWidth != nil {
+            toolbarScroll.contentSize.width = contentWidth!
+            toolbar.frame.size.width = contentWidth!
+            toolbar.frame.size.height = 44
+            return
+        }
+        
         let defaultIconWidth: CGFloat = 22
         let barButtonItemMargin: CGFloat = 11
         var width: CGFloat = buttons.reduce(0) {sofar, new in

--- a/RichEditorView/Classes/RichEditorToolbar.swift
+++ b/RichEditorView/Classes/RichEditorToolbar.swift
@@ -85,9 +85,12 @@ public class RichEditorToolbar: UIView {
     }
     
     /**
-        The inner toolbar that contains the list of options as UIBarButtonItems.
+        The bar button items that are displayed as options.
+        Useful for presenting popovers from.
     */
-    public var toolbar: UIToolbar
+    public var barButtonItems : [UIBarButtonItem]? {
+        return toolbar.items as? [UIBarButtonItem]
+    }
     
     /**
         Set this to specify a content width.  Not setting this will have the editor try to 
@@ -98,6 +101,8 @@ public class RichEditorToolbar: UIView {
             updateToolbar()
         }
     }
+    
+    private var toolbar: UIToolbar
     
     private var toolbarScroll: UIScrollView
     

--- a/RichEditorView/Classes/RichEditorView.swift
+++ b/RichEditorView/Classes/RichEditorView.swift
@@ -204,7 +204,7 @@ extension RichEditorView {
     }
     
     public func setFontSize(size: Int) {
-        runJS("RE.setFontSize('\(size))px');")
+        runJS("RE.setFontSize('\(size)px');")
     }
     
     public func setEditorBackgroundColor(color: UIColor) {


### PR DESCRIPTION
Thanks for the sharing the library.  I was having some trouble where the content width wasn't expanding far enough when using autolayout.  Currently its impossible to re-calculate.  These features allow me to get around the issue.