### PR TITLE
Implement the getSelectedHref method

### DIFF
--- a/RichEditorView/Assets/editor/rich_editor.js
+++ b/RichEditorView/Assets/editor/rich_editor.js
@@ -269,3 +269,17 @@ RE.focus = function() {
 RE.blurFocus = function() {
     RE.editor.blur();
 }
+
+/**
+ * If the current selection's parent is an anchor tag, get the href.
+ * @returns {string}
+ */
+RE.getSelectedHref = function() {
+    var href, sel;
+    href = '';
+    sel = window.getSelection();
+    if (sel != null && sel.focusNode && sel.focusNode.parentElement) {
+        href = sel.focusNode.parentElement.getAttribute('href');
+    }
+    return href;
+}

--- a/RichEditorView/Classes/RichEditorView.swift
+++ b/RichEditorView/Classes/RichEditorView.swift
@@ -332,8 +332,25 @@ extension RichEditorView {
         runJS("RE.blurFocus()")
     }
 
+    /**
+    * Looks specifically for a selection of type "Range"
+    **/
     public func rangeSelectionExists() -> Bool {
         return runJS("RE.rangeSelectionExists();") == "true" ? true : false
+    }
+
+    /**
+    * If the current selection's parent is an anchor tag, get the href.
+    * @returns nil if href is empty, otherwise a non-empty String
+    */
+    public func getSelectedHref() -> String? {
+        if !rangeSelectionExists() { return nil }
+        let href = runJS("RE.getSelectedHref();")
+        if href == "" {
+            return nil
+        } else {
+            return href
+        }
     }
 }
 


### PR DESCRIPTION
To add a bit of context, you want a method like this if you select an existing link in your richtext editor and want to edit it. This method allows us to pre-fill out the textfield in the "edit link" view controller.