### PR TITLE
Update height after content images are loaded

### DIFF
--- a/RichEditorView/Assets/editor/rich_editor.js
+++ b/RichEditorView/Assets/editor/rich_editor.js
@@ -66,6 +66,10 @@ RE.customAction = function(action) {
     RE.callback("action/" + action);
 };
 
+RE.updateHeight = function() {
+    RE.callback("updateHeight");
+}
+
 RE.callbackQueue = [];
 RE.runCallbackQueue = function() {
     if (RE.callbackQueue.length === 0) {
@@ -89,7 +93,15 @@ RE.callback = function(method) {
 };
 
 RE.setHtml = function(contents) {
-    RE.editor.innerHTML = contents;
+    var tempWrapper = document.createElement('div');
+    tempWrapper.innerHTML = contents;
+    var images = tempWrapper.querySelectorAll("img");
+
+    for (var i = 0; i < images.length; i++) {
+        images[i].onload = RE.updateHeight;
+    }
+
+    RE.editor.innerHTML = tempWrapper.innerHTML;
     RE.updatePlaceholder();
 };
 
@@ -208,8 +220,12 @@ RE.setJustifyRight = function() {
 };
 
 RE.insertImage = function(url, alt) {
-    var html = '<img src="' + url + '" alt="' + alt + '" />';
-    RE.insertHTML(html);
+    var img = document.createElement('img');
+    img.setAttribute("src", url);
+    img.setAttribute("alt", alt);
+    img.onload = RE.updateHeight;
+
+    RE.insertHTML(img.outerHTML);
     RE.callback("input");
 };
 

--- a/RichEditorView/Classes/RichEditorView.swift
+++ b/RichEditorView/Classes/RichEditorView.swift
@@ -517,6 +517,9 @@ extension RichEditorView {
             contentHTML = content
             updateHeight()
         }
+        else if method.hasPrefix("updateHeight") {
+            updateHeight()
+        }
         else if method.hasPrefix("focus") {
             delegate?.richEditorTookFocus?(self)
         }


### PR DESCRIPTION
First of all, thanks for the great library!

I'm using it inside a [react-native](https://github.com/facebook/react-native) project, and my use case is heavily dependant on editor view's height. I've discovered that my view height is wrong when the editor content contains an image. After investigation, i managed to fix my problem by updating view height when content images are loaded.

You can test the problem by setting editor html manually in demo projects. You can observe that initial height will be 56 and it will be 164 after image is loaded:

`[self.editorView setHTML:@"Image Test<div><img src=\"https://images.google.com/images/branding/googleg/1x/googleg_standard_color_128dp.png\" alt=\"google\"></div>"];`

I hope you find this PR useful.