### PR TITLE
Scroll cursor back into view when it goes out of bounds

### DIFF
--- a/RichEditorView.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/RichEditorView.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/RichEditorView/Assets/editor/rich_editor.html
+++ b/RichEditorView/Assets/editor/rich_editor.html
@@ -6,8 +6,8 @@
     <link rel="stylesheet" type="text/css" href="normalize.css"> 
     <link rel="stylesheet" type="text/css" href="style.css">
 </head>
-<body><div id="editor" contentEditable="true" placeholder="" class="placeholder">
-</div>
+<body>
+<div id="editor" contentEditable="true" placeholder="" class="placeholder"></div>
 <script type="text/javascript" src="rich_editor.js"></script>
 </body>
 </html>

--- a/RichEditorView/Assets/editor/rich_editor.js
+++ b/RichEditorView/Assets/editor/rich_editor.js
@@ -383,7 +383,7 @@ RE.getCaretPosition = function() {
         var needsWorkAround = (range.startContainer.nodeName.toLowerCase() == 'div' && range.startOffset == 0);
         if (needsWorkAround) {
             x=range.startContainer.offsetLeft;
-            y=range.startContainer.offsetTop;
+            y=range.startContainer.offsetTop + range.startContainer.clientHeight;
         } else {
             if (range.getClientRects) {
                 var rects=range.getClientRects();

--- a/RichEditorView/Assets/editor/rich_editor.js
+++ b/RichEditorView/Assets/editor/rich_editor.js
@@ -414,7 +414,9 @@ RE.getCaretPosition = function() {
     var sel=window.getSelection();
     if (sel.rangeCount) {
         var range = sel.getRangeAt(0);
-        var needsWorkAround = (range.startContainer.nodeName.toLowerCase() == 'div' && range.startOffset == 0);
+        var needsWorkAround = (range.startOffset == 0)
+        /* Removing fixes bug when node name other than 'div' */
+        // && range.startContainer.nodeName.toLowerCase() == 'div');
         if (needsWorkAround) {
             console.log(range);
             x=range.startContainer.offsetLeft;

--- a/RichEditorView/Assets/editor/rich_editor.js
+++ b/RichEditorView/Assets/editor/rich_editor.js
@@ -379,7 +379,7 @@ RE.getSelectedHref = function() {
 RE.wrapTextNodes = function() {
     var contents = RE.editor.childNodes;
     for (var i = 0; i < contents.length; i++) {
-        if (contents[i].nodeType === 3) {
+        if (contents[i].nodeType === Node.TEXT_NODE) {
             var newNode = document.createElement('div');
             RE.createWrapper(contents[i], newNode);
             RE.focus();
@@ -418,7 +418,6 @@ RE.getCaretPosition = function() {
         /* Removing fixes bug when node name other than 'div' */
         // && range.startContainer.nodeName.toLowerCase() == 'div');
         if (needsWorkAround) {
-            console.log(range);
             x=range.startContainer.offsetLeft;
             y=range.startContainer.offsetTop; // add range.startContainer.clientHeight if want bottom of caret;
             newLine = true; // position is on new line with no content
@@ -434,6 +433,5 @@ RE.getCaretPosition = function() {
         }
     }
     var json = JSON.stringify({height: y, newLine: newLine});
-    console.log(json);
     return json;
 };

--- a/RichEditorView/Assets/editor/rich_editor.js
+++ b/RichEditorView/Assets/editor/rich_editor.js
@@ -372,3 +372,27 @@ RE.getSelectedHref = function() {
 
     return href ? href : null;
 };
+
+/* retrieve caret vertical position */
+
+RE.getCaretPosition = function() {
+    var x=0, y=0;
+    var sel=window.getSelection();
+    if (sel.rangeCount) {
+        var range = sel.getRangeAt(0);
+        var needsWorkAround = (range.startContainer.nodeName.toLowerCase() == 'div' && range.startOffset == 0);
+        if (needsWorkAround) {
+            x=range.startContainer.offsetLeft;
+            y=range.startContainer.offsetTop + range.startContainer.offsetHeight;
+        } else {
+            if (range.getClientRects) {
+                var rects=range.getClientRects();
+                if (rects.length > 0) {
+                    x = rects[0].left;
+                    y = rects[0].bottom;
+                }
+            }
+        }
+    }
+    return y;
+};

--- a/RichEditorView/Assets/editor/rich_editor.js
+++ b/RichEditorView/Assets/editor/rich_editor.js
@@ -383,7 +383,7 @@ RE.getCaretPosition = function() {
         var needsWorkAround = (range.startContainer.nodeName.toLowerCase() == 'div' && range.startOffset == 0);
         if (needsWorkAround) {
             x=range.startContainer.offsetLeft;
-            y=range.startContainer.offsetTop + range.startContainer.offsetHeight;
+            y=range.startContainer.offsetTop;
         } else {
             if (range.getClientRects) {
                 var rects=range.getClientRects();

--- a/RichEditorView/Assets/editor/style.css
+++ b/RichEditorView/Assets/editor/style.css
@@ -57,7 +57,7 @@ div {
     overflow: auto;
     display: block;
     font-family: 'HelveticaNeue';
-	color:#666666; 
-	line-height:28px; 
-	font-size: 12pt;
+    color:#666666;
+    line-height:28px;
+    font-size: 12pt;
 }

--- a/RichEditorView/Assets/editor/style.css
+++ b/RichEditorView/Assets/editor/style.css
@@ -17,7 +17,7 @@
 @charset "UTF-8";
 
 html {
-    min-height: 100%;
+    height: 100%;
 }
 
 body {

--- a/RichEditorView/Assets/editor/style.css
+++ b/RichEditorView/Assets/editor/style.css
@@ -22,11 +22,18 @@ html {
 
 body {
     min-height: 100%;
-    overflow: hidden;
+    height: 100%;
+    overflow: auto;
 }
 
 body, h1, p {
     margin: 0;
+}
+
+div {
+    display: block;
+    position: static;
+    min-height: 28px;
 }
 
 #editor {
@@ -47,6 +54,9 @@ body, h1, p {
 
 #editor {
     min-height: 100%;
+    height: 100%;
+    overflow: auto;
+    display: block;
 	font-family: 'HelveticaNeue';
 	color:#666666; 
 	line-height:28px; 

--- a/RichEditorView/Assets/editor/style.css
+++ b/RichEditorView/Assets/editor/style.css
@@ -17,12 +17,11 @@
 @charset "UTF-8";
 
 html {
-    height: 100%;
+    min-height: 100%;
 }
 
 body {
     min-height: 100%;
-    height: 100%;
     overflow: auto;
 }
 

--- a/RichEditorView/Assets/editor/style.css
+++ b/RichEditorView/Assets/editor/style.css
@@ -56,7 +56,7 @@ div {
     height: 100%;
     overflow: auto;
     display: block;
-	font-family: 'HelveticaNeue';
+    font-family: 'HelveticaNeue';
 	color:#666666; 
 	line-height:28px; 
 	font-size: 12pt;

--- a/RichEditorView/Classes/RichEditorView.swift
+++ b/RichEditorView/Classes/RichEditorView.swift
@@ -464,9 +464,10 @@ extension RichEditorView {
         let caretPosition: String = editor.getCaretPosition()
         
         if let caretPositionNumeric = NSNumberFormatter().numberFromString(caretPosition) {
-            let caretFloat = CGFloat(caretPositionNumeric)
+            let caretFloat = CGFloat(caretPositionNumeric) - scrollView.contentOffset.y
             if caretFloat >= (scrollView.bounds.size.height) {
-                let bottomOffset = CGPointMake(0, scrollView.contentSize.height - scrollView.bounds.size.height + scrollView.contentInset.bottom)
+                let bottomOffset = CGPointMake(0, (caretFloat + scrollView.contentOffset.y) - scrollView.bounds.size.height + scrollView.contentInset.bottom
+                )
                 scrollView.setContentOffset(bottomOffset, animated: true)
             }
         }

--- a/RichEditorView/Classes/RichEditorView.swift
+++ b/RichEditorView/Classes/RichEditorView.swift
@@ -478,27 +478,26 @@ extension RichEditorView {
         if let caretPositionNumeric = data!["height"] as? NSNumber {
             
             let caretFloat = CGFloat(caretPositionNumeric) - scrollView.contentOffset.y
-
-            var relativeCaretPosition: CGFloat?
             
-            if caretPositionNumeric.floatValue < 0 {
-                relativeCaretPosition = scrollView.contentOffset.y - abs(CGFloat(caretPositionNumeric.floatValue))
+            var CGFloatCaretPositionNumeric = CGFloat(caretPositionNumeric.floatValue)
+            if newLine {
+                if (caretFloat + 24.0) > (scrollView.bounds.size.height) {
+                    let bottomOffset = CGPointMake(0, (CGFloat(caretPositionNumeric.floatValue) - (scrollView.bounds.size.height + scrollView.contentOffset.y)) + scrollView.contentOffset.y + 28.0)
+                    scrollView.setContentOffset(bottomOffset, animated: true)
+                } else if (CGFloatCaretPositionNumeric < scrollView.contentOffset.y) && scrollView.contentOffset.y > 0 {
+                    let bottomOffset = CGPointMake(scrollView.contentOffset.x, CGFloatCaretPositionNumeric)
+                    scrollView.setContentOffset(bottomOffset, animated: true)
+                }
             } else {
-                relativeCaretPosition = CGFloat(caretPositionNumeric.floatValue)
-            }
-            
-            if (caretFloat + 28.0) >= (scrollView.bounds.size.height) { // 28px for height of caret (line-height: 28px;)
-                let bottomOffset = CGPointMake(0, ((caretFloat + 28.0) + scrollView.contentOffset.y) - scrollView.bounds.size.height + scrollView.contentInset.bottom)
-                scrollView.setContentOffset(bottomOffset, animated: true)
-            } else if (caretPositionNumeric.floatValue < 0) {
-                var amount = CGFloat(caretPositionNumeric.floatValue) < 0 ? CGFloat(caretPositionNumeric.floatValue * -1.0) : CGFloat(caretPositionNumeric.floatValue)
-                var vertOffset = relativeCaretPosition < 0 ? 0 : relativeCaretPosition
-                let bottomOffset = CGPointMake(scrollView.contentOffset.x, CGFloat(vertOffset!))
-                scrollView.setContentOffset(bottomOffset, animated: true)
-            } else  if (relativeCaretPosition < scrollView.contentOffset.y) && newLine && scrollView.contentOffset.y > 0 {
-                var vertOffset = relativeCaretPosition
-                let bottomOffset = CGPointMake(scrollView.contentOffset.x, CGFloat(vertOffset!))
-                scrollView.setContentOffset(bottomOffset, animated: true)
+                if CGFloatCaretPositionNumeric + 24.0 > scrollView.bounds.size.height {
+                    let bottomOffset = CGPointMake(0, ((CGFloatCaretPositionNumeric - scrollView.bounds.size.height) + scrollView.contentOffset.y + 28.0))
+                    scrollView.setContentOffset(bottomOffset, animated: true)
+                } else if (CGFloatCaretPositionNumeric < 0) {
+                    var amount = scrollView.contentOffset.y + CGFloatCaretPositionNumeric
+                    amount = amount < 0 ? 0 : amount
+                    let bottomOffset = CGPointMake(scrollView.contentOffset.x, amount)
+                    scrollView.setContentOffset(bottomOffset, animated: true)
+                }
             }
         }
         

--- a/RichEditorViewSample/RichEditorViewSample/KeyboardManager.swift
+++ b/RichEditorViewSample/RichEditorViewSample/KeyboardManager.swift
@@ -36,8 +36,8 @@ class KeyboardManager: NSObject {
         Starts monitoring for keyboard notifications in order to show/hide the toolbar
     */
     func beginMonitoring() {
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(KeyboardManager.keyboardWillShowOrHide(_:)), name: UIKeyboardWillShowNotification, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(KeyboardManager.keyboardWillShowOrHide(_:)), name: UIKeyboardWillHideNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("KeyboardManager.keyboardWillShowOrHide:"), name: UIKeyboardWillShowNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("KeyboardManager.keyboardWillShowOrHide:"), name: UIKeyboardWillHideNotification, object: nil)
     }
 
     /**


### PR DESCRIPTION
## Fix #3 
- Add JS method to calculate the caret position within the RichEditorView

- Set scrollView contentSize.height based on html content height

- Change scrollView's contentOffset if caret is outside of RichEditorView's bounds