### PR TITLE
Fix for focus issue iOS 10.3.1 when no content

### DIFF
--- a/RichEditorView/Assets/editor/rich_editor.js
+++ b/RichEditorView/Assets/editor/rich_editor.js
@@ -318,7 +318,7 @@ RE.focus = function() {
 };
 
 RE.focusAtPoint = function(x, y) {
-    var range = document.caretRangeFromPoint(x, y);
+    var range = document.caretRangeFromPoint(x, y) || document.createRange();
     var selection = window.getSelection();
     selection.removeAllRanges();
     selection.addRange(range);


### PR DESCRIPTION
Right now if there is no content, the focusAtPoint doesn't work, so when you tap on the screen (in an area outside of the placeholder) it dismisses the keyboard instead of focusing and beginning selection. 

The fix is just adding a null coalescent to the default range if `document.caretRangeFromPoint` fails.