### PR TITLE
Fix remove format not handling headers

### DIFF
--- a/RichEditorView/Assets/editor/rich_editor.js
+++ b/RichEditorView/Assets/editor/rich_editor.js
@@ -132,6 +132,7 @@ RE.updatePlaceholder = function() {
 RE.removeFormat = function() {
     // https://stackoverflow.com/a/52137754/4514671
     // https://stackoverflow.com/questions/14028773/javascript-execcommandremoveformat-doesnt-strip-h2-tag
+    // fix for body button not formatting headers
     // formatting to 'p' because removeFormat cannot deal with headers (h1, h2, ...)
     document.execCommand('formatBlock', false, 'p');
     document.execCommand('removeFormat', false, null);


### PR DESCRIPTION
Issue: Inside the Posting Text  Block the Body button would not convert the headers (once set) back to it's original format (only bold, italics etc. would work, but no headers)

I know I'm an iOS dev and this is js, but this was the solution for the issue.