### PR TITLE
formatting to 'p' because removeFormat cannot deal with headers

### DIFF
--- a/RichEditorView/Assets/editor/rich_editor.js
+++ b/RichEditorView/Assets/editor/rich_editor.js
@@ -130,6 +130,10 @@ RE.updatePlaceholder = function() {
 };
 
 RE.removeFormat = function() {
+    // https://stackoverflow.com/a/52137754/4514671
+    // https://stackoverflow.com/questions/14028773/javascript-execcommandremoveformat-doesnt-strip-h2-tag
+    // formatting to 'p' because removeFormat cannot deal with headers (h1, h2, ...)
+    document.execCommand('formatBlock', false, 'p');
     document.execCommand('removeFormat', false, null);
 };
 


### PR DESCRIPTION
https://stackoverflow.com/a/52137754/4514671
https://stackoverflow.com/questions/14028773/javascript-execcommandremoveformat-doesnt-strip-h2-tag

I'm not a js dev (iOS) so here are the references