### PR TITLE
feat: support dark mode

### DIFF
--- a/RichEditorView.podspec
+++ b/RichEditorView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "RichEditorView"
-  s.version          = "5.0.0"
+  s.version          = "6.0.0"
   s.summary          = "Rich Text Editor for iOS written in Swift"
   s.homepage         = "https://github.com/cjwirth/RichEditorView"
   s.license          = 'BSD 3-clause'
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.social_media_url = 'https://twitter.com/cjwirth'
 
   s.platform     = :ios, '8.0'
-  s.swift_version = '4.0'
+  s.swift_version = '5.0'
   s.requires_arc = true
 
   s.source_files = 'RichEditorView/Classes/*'

--- a/RichEditorView.xcodeproj/project.pbxproj
+++ b/RichEditorView.xcodeproj/project.pbxproj
@@ -400,6 +400,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = FBA6AAEF1AD3EC9F00721644;
@@ -560,6 +561,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -602,6 +604,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -624,7 +627,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -642,7 +645,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cjwirth.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -658,7 +661,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cjwirth.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -670,7 +673,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cjwirth.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/RichEditorView/Assets/editor/rich_editor.js
+++ b/RichEditorView/Assets/editor/rich_editor.js
@@ -21,6 +21,7 @@ window.onload = function() {
     RE.callback("ready");
 };
 
+RE.body = document.getElementsByTagName('body')[0];
 RE.editor = document.getElementById('editor');
 
 // Not universally supported, but seems to work in iOS 7 and 8
@@ -138,7 +139,7 @@ RE.setFontSize = function(size) {
 };
 
 RE.setBackgroundColor = function(color) {
-    RE.editor.style.backgroundColor = color;
+    RE.body.style.backgroundColor = color;
 };
 
 RE.setHeight = function(size) {

--- a/RichEditorView/Assets/editor/style.css
+++ b/RichEditorView/Assets/editor/style.css
@@ -23,6 +23,13 @@ html {
 body {
     min-height: 100%;
     overflow: auto;
+    background-color: white;
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: black;
+    }
 }
 
 body, h1, p {
@@ -58,4 +65,10 @@ div {
     font-family: 'HelveticaNeue';
     color:#666666;
     font-size: 12pt;
+}
+
+@media (prefers-color-scheme: dark) {
+    #editor {
+        color: white;
+    }
 }

--- a/RichEditorView/Classes/RichEditorView.swift
+++ b/RichEditorView/Classes/RichEditorView.swift
@@ -135,7 +135,6 @@ import UIKit
     }
     
     private func setup() {
-        backgroundColor = .red
         
         webView.frame = bounds
         webView.delegate = self
@@ -143,7 +142,6 @@ import UIKit
         webView.scalesPageToFit = false
         webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         webView.dataDetectorTypes = UIDataDetectorTypes()
-        webView.backgroundColor = .white
         
         webView.scrollView.isScrollEnabled = isScrollEnabled
         webView.scrollView.bounces = false
@@ -368,7 +366,7 @@ import UIKit
 
     // MARK: UIWebViewDelegate
 
-    public func webView(_ webView: UIWebView, shouldStartLoadWith request: URLRequest, navigationType: UIWebViewNavigationType) -> Bool {
+    public func webView(_ webView: UIWebView, shouldStartLoadWith request: URLRequest, navigationType: UIWebView.NavigationType) -> Bool {
 
         // Handle pre-defined editor actions
         let callbackPrefix = "re-callback://"


### PR DESCRIPTION
This pull requests adds support for iOS 13+ dark mode while maintaining full backwards compatibility - by using CSS media queries.

To build with Xcode 11, I also needed to move the project to Swift 5 which might collide with #203, but I'm free to rebase these changes once the other pull request is merged.

Thanks!